### PR TITLE
fixing ffmpeg relative path issue

### DIFF
--- a/config.js
+++ b/config.js
@@ -1,24 +1,3 @@
-// One document to hold relative paths and make sure
-// the correct packages are linked to ensure
-// FFmpeg functionality
-
-// var path = require("path");
-// // https://nodejs.org/api/path.html#path_path_resolve_paths
-// var appDir = path.resolve("./package.json");
-//
-// // const {app} = require('electron');
-// var ffmpegPathish = require('ffmpeg-static').path;
-// console.log('./node_modules/ffmpeg-static/'+ ffmpegPathish)
-// var ffprobePathish = require('ffprobe-static').path;
-//
-// var ffmpegPath = 'node_modules/ffmpeg-static/'+ffmpegPathish)
-// var ffprobePath = 'node_modules/ffprobe-static/'+ffprobePathish)
-//
-// module.exports = {
-//   ffmpegPath: ffmpegPath,
-//   ffprobePath: ffprobePath
-// };
-
 var path = require("path");
 // https://nodejs.org/api/path.html#path_path_resolve_paths
 // var appDir = path.resolve("./package.json");

--- a/index.html
+++ b/index.html
@@ -49,59 +49,17 @@
       Loading...
       <!-- <script src="./bundle/renderer.bundle.js"></script> -->
     </div>
-    <div id="test">
-      <div id="msgs">results of this experiment will go here:</div>
-    </div>
   </body>
 
   <script>
-   //  // var fs = require('file-system');
-   //  // fs.recurse('/Users/mwhitely/desktop/knight-lab/2017-2018/jam/electron-quick-start',
-   //  // function(filepath, relative, filename){
-   //  //   document.getElementById("results").append(filename);
-   //  // });
-   //  var fluent_ffmpeg = require('fluent-ffmpeg');
-   //  var ffmpegPath  = require("./config.js").ffmpegPath;
-   //  var ffprobePath = require("./config.js").ffprobePath;
-   //  const path = require('path');
-   //
-   //  fluent_ffmpeg.setFfmpegPath(ffmpegPath);
-   //  fluent_ffmpeg.setFfprobePath(ffprobePath);
-   //
-   //  //initialize global variables
-   //  var mergedVideo = fluent_ffmpeg();
-   //
-   //  var vid1 = document.getElementById("v1");
-   //  var vid2 = document.getElementById("v2");
-   //  var makeVidBtn = document.getElementById("concat");
-   //
-   //  // vid1.onchange = console.log(vid1);
-   //  //
-   //  // makeVidBtn.onClick = console.log("You clicked")
-   //  // makeVidBtn.onclick = concatVidClips();
-   //
-   //  function concatVidClips() {
-  	// 	var outPath = path.join(__dirname, 'out.mp4');
-  	// 	var msgArea = document.getElementById("msgs");
-   //
-  	// 	var proc = fluent_ffmpeg(vid1.files[0].path)
-  	//     .input(vid2.files[0].path)
-  	// 		.on('progress', function(progress) {
-   //  			// console.log('Processing: ' + progress.percent + '% done');
-  	// 			msgArea.innerHTML += 'Processing: ' + progress.percent + '% done\n';
-  	// 		})
-  	//     .on('end', function() {
-  	//       console.log('files have been merged succesfully');
-  	// 			msgArea.innerHTML += 'files have been merged succesfully';
-  	//     })
-  	//     .on('error', function(err) {
-  	//       console.log('an error happened: ' + err.message);
-  	// 			msgArea.innerHTML += 'an error happened: ' + err.message;
-  	//     })
-  	//     .mergeToFile(outPath);
-	 // }
-
+    var fluent_ffmpeg = require('fluent-ffmpeg');
+    var ffmpegPath  = require("./config.js").ffmpegPath;
+    var ffprobePath = require("./config.js").ffprobePath;
+    const path = require('path');
+    fluent_ffmpeg.setFfmpegPath(ffmpegPath);
+    fluent_ffmpeg.setFfprobePath(ffprobePath);
   </script>
+
 
   <script>
     // You can also require other files to run in this process

--- a/src/ClipCard/ClipCard.jsx
+++ b/src/ClipCard/ClipCard.jsx
@@ -4,10 +4,6 @@ var fs = require("fs");
 
 // Set up FFmpeg
 var fluent_ffmpeg = require('fluent-ffmpeg');
-var ffmpegPath  = require("./../../config.js").ffmpegPath;
-var ffprobePath = require("./../../config.js").ffprobePath;
-fluent_ffmpeg.setFfmpegPath(osHomedir() + '/desktop/knight-lab/2017-2018/jam/videojam/node_modules/ffmpeg-static' + ffmpegPath);
-fluent_ffmpeg.setFfprobePath(osHomedir() + '/desktop/knight-lab/2017-2018/jam/videojam/node_modules/ffprobe-static' + ffprobePath);
 var mergedVideo = fluent_ffmpeg();
 
 
@@ -34,7 +30,6 @@ export default class ClipCard extends React.Component {
     clipCard.text = event.target.value;
     this.setState({
       'clipCard': clipCard,
-      // 'clipCard.text': event.target.value,
       // 'clipCard.text': event.target.value,
     });
   }

--- a/src/app.js
+++ b/src/app.js
@@ -10,8 +10,10 @@ var tmpobj = tmp.dirSync({unsafeCleanup: true});
 var fluent_ffmpeg = require('fluent-ffmpeg');
 var ffmpegPath  = require("./../config.js").ffmpegPath;
 var ffprobePath = require("./../config.js").ffprobePath;
-fluent_ffmpeg.setFfmpegPath(osHomedir() + '/desktop/knight-lab/2017-2018/jam/videojam/node_modules/ffmpeg-static' + ffmpegPath);
-fluent_ffmpeg.setFfprobePath(osHomedir() + '/desktop/knight-lab/2017-2018/jam/videojam/node_modules/ffprobe-static' + ffprobePath);
+// fluent_ffmpeg.setFfmpegPath(ffmpegPath);
+// fluent_ffmpeg.setFfprobePath(ffprobePath);
+fluent_ffmpeg.setFfmpegPath('./node_modules/ffmpeg-static' + ffmpegPath);
+fluent_ffmpeg.setFfprobePath('./node_modules/ffprobe-static' + ffprobePath);
 
 //initialize global variables
 var mergedVideo = fluent_ffmpeg();
@@ -29,11 +31,6 @@ export default class App extends React.Component {
     super(props);
     this.state = {
       clipCards: [],
-      // font: 'Verdana.ttf',
-      // color: '#000000',
-      // music: 'music.mp3',
-      // logo: 'logo.png',
-      // aspect: '1:1',
       globalPresets: {
         font: 'Verdana.ttf',
         color: '#000000',
@@ -103,18 +100,25 @@ export default class App extends React.Component {
   concatClips(event) {
     var clipsFolder = './clips';
     var clipNumber = 0
+    var x = 0;
     var clipPaths = []
     fs.readdir(clipsFolder, (err, files) => {
         console.log(files.length);
         clipNumber = files.length;
         files.forEach(function(file) {
           clipPaths.push(file)
+          mergedVideo.addInput(file)
+          x++
         });
     });
-    clipPaths.forEach(function(clip) {
-      mergedVideo.input(clip)
-    })
-    mergedVideo.mergeToFile('./final.mov')
+    // var jj = 0
+    // clipPaths.forEach(function(clip) {
+    //   mergedVideo.addInput(clip)
+    //   ++jj
+    // });
+    if (x == clipNumber) {
+      mergedVideo.mergeToFile('./final.mov')
+    }
   }
 
   render() {
@@ -136,110 +140,3 @@ export default class App extends React.Component {
     );
   }
 }
-
-
-// instantiate React component:
-// https://stackoverflow.com/questions/36471869/rendering-a-string-as-react-component#comment60556701_36471869
-
-// getCards()
-//
-// addVideoObjects(event) {
-//   var clipCards = this.state.clipCards;
-//   var videoObjects = this.state.videoObjects;
-//   this.setState({
-//     videoObjects: videoObjects.concat()
-//   });
-// }
-//
-// componentDidUpdate() {
-//   console.log("Hi!!")
-// }
-
-// adds the most recently added video clip path to the
-// videoPaths array
-// addPath(event) {
-//   var videoPaths = this.state.videoPaths;
-//   var mediaCount = this.state.mediaCount;
-//   //find a more elegant way to do this
-//   var videoPath = event.target.files[0].path;
-//
-//   this.setState({
-//     //array only contains most recent path...
-//     'videoPaths': videoPaths.push(videoPath),
-//     'mediaCount': ++mediaCount
-//   });
-//   console.log(videoPath)
-//   console.log(videoPaths)
-// }
-
-
-    // clipCards.forEach(function(clipCard) {
-    //   var outStream = fs.createWriteStream('./' + x + '.mov');
-    //   console.log(outStream.path);
-    //   fluent_ffmpeg(clipCard.mediaPath)
-    //     .size('1200x?')
-    //     .aspect('1:1')
-    //     .autopad()
-		// 	  .toFormat('mov')
-    //     .duration(5.0)
-    //     .videoCodec('libx264')
-    // 		.noAudio()
-    //     //frag_keyframe allows fragmented output & empty_moov will cause
-    //     //output to be 100% fragmented; without this the first fragment
-    //     //will be muxed as a short movie (using moov) followed by the
-    //     //rest of the media in fragments.
-    //     .outputOptions('-movflags frag_keyframe+empty_moov')
-    //     .outputOptions('-strict -2')
-    //     // .output(outStream)
-    //     // .run()
-    //     // .pipe(outStream, { end: true })
-    //     // .saveToFile(outStream)
-    //     .on('error', function(err) {
-    //       console.log('An error occurred: ' + err.message);
-		//   	})
-    //     .on('end', function() {
-    //       console.log('Processing finished !')
-    //     })
-    //     // .pipe(outStream, { end: true })
-    //     .save(outStream)
-    //     ++x
-          // mergedVideo = mergedVideo.addInput(tmpobj.name + '/' + jj + '.mov');
-          // x++;
-      		// if (x == videoCount) {
-          //   mergedVideo.mergeToFile('final.mov', './tmp/')
-      		// 	  .videoCodec('libx264')
-      	  //     .audioCodec('libmp3lame')
-      		// 		.format('mov')
-      		// 		.outputOptions('-movflags frag_keyframe+empty_moov')
-      		// 		.on('error', function(err) {
-      		// 		  console.log('Error ' + err.message);
-      		// 		})
-      		// 		.on('end', function() {
-          //       console.log('Finished!');
-          //     })
-          // }
-    // .pipe(outStream, { end: true });
-        // .pipe('final.mp4', { end: true });
-  //   })
-  // }
-
-
-
-  // concatClips(event) {
-  //   var outPath = path.join(__dirname, 'out.mp4');
-  //   // var outPath = './out.mp4';
-  //   // var msgArea = document.getElementById("msgs");
-  //
-  //   var clipCards = this.state.clipCards;
-  //   var x = 0;
-  //
-  //   var addOn = 'fluent_ffmpeg('+ clipCards[0].mediaPath + ')'
-  //   console.log(clipCards)
-  //
-  //   console.log()
-  //   clipCards.forEach(function(clipCard) {
-  //     addOn += '.input'+(clipCard.mediaPath)
-  //   })
-  //   // console.log(addOn)
-  //   // var outStream = fs.createWriteStream('./' + x + '.mov');
-  // }


### PR DESCRIPTION
Currently, the paths to  `ffmpeg-static` and `ffprobe-static` (which are being used to define where `fluent-ffmpeg` should grab its resources from) are relative (but less relative so they should work for local development): `'./node_modules/<ffthing>-static' + <ffthing>Path`. The only place in the `src` directory that needs a functioning path to a packagable `fluent-ffmpeg` is `app.js` since every other element is a component of it. 