### PR TITLE
Link editor window to clip cards with button

### DIFF
--- a/src/ClipCard/ClipCard.css
+++ b/src/ClipCard/ClipCard.css
@@ -6,6 +6,7 @@
 }
 
 .clipCard {
+  padding-top: 20px;
   margin: 10px;
   width: 250px;
   height: 125px;

--- a/src/ClipCard/ClipCard.css
+++ b/src/ClipCard/ClipCard.css
@@ -14,6 +14,16 @@
   background-color: #cdcdcd;
 }
 
+#numbercontainer {
+  display: flex;
+  justify-content: space-between;
+}
+
+#cardindex {
+  margin-right: 10px;
+  text-align: center;
+}
+
 .clipText {
   background-color: #737373;
   color: black;

--- a/src/ClipCard/ClipCard.jsx
+++ b/src/ClipCard/ClipCard.jsx
@@ -16,13 +16,8 @@ export default class ClipCard extends React.Component {
         },
         id: '',
   		}
-    // this.setText = this.setText.bind(this);
     this.placeText = this.placeText.bind(this);
-    this.updateText = this.updateText.bind(this);
-    // this.setMediaPath = this.setMediaPath.bind(this);
-    // this.passUp = this.passUp.bind(this);
     this.updateEditor = this.updateEditor.bind(this);
-    // this.updateCardContainer = this.updateCardContainer.bind(this);
 	}
 
   componentDidMount() {
@@ -51,49 +46,20 @@ export default class ClipCard extends React.Component {
   // MANUALLY puts text/id of individ clipCard into editor window.
   // DOESN'T use state, but this function needs to use clipContainer state
   placeText(event) {
+    // grab editor window elements
     var editorText = document.getElementById("editorText");
-    // editorText.cardindex = this.props.index;
-    // editorText.cardkey = this.state.id;
-    // var editorTextIndex = editorText.cardindex
-    // var cardContainer = this.props.cardContainer;
-    console.log(event.target.children[1].value)
-    editorText.value = event.target.children[1].value;
-    // var currCardInfo = cardContainer[editorTextIndex]
-    // var currCardText = document.getElementById(currCardInfo['id']).children[0].children[1]
-    // console.log("desired text: ", currCardText.value)
-    // editorText.value = currCardText.value;
+    var editorVideo = document.getElementById("editorVideo");
 
-    // var clipCard = this.state.clipCard;
-    // console.log(clipCard)
-    // editorText.cardindex = this.props.index;
+    // set attributes to be specific to the card selected
+    editorText.cardindex = this.props.index;
+    editorText.cardkey = this.state.id;
+    editorVideo.cardindex = this.props.index;
+    editorVideo.cardkey = this.state.id;
+
+    // set the editor window attributes to be the selected card vals
+    editorText.value = event.target.children[0].children[1].value;
+    editorVideo.src = event.target.children[2].src;
   }
-
-  // updateText(event) {
-  //   var cardContainer = this.props.cardContainer;
-  //   // console.log("omg")
-  //
-  //   for (var i = 0; i < cardContainer.length; i++) {
-  //     if (cardContainer[i].id = event.target.id) {
-  //       console.log("event id: " + event.target.id)
-  //       console.log("text of cc: " + cardContainer[i].text)
-  //       event.target.value = cardContainer[i].text;
-  //     }
-  //     else { i++ }
-  //   }
-  // }
-
-  // TRIES (fails) to set its text to editor window's text
-  // setText(event) {
-  //   var clipCard = this.state.clipCard;
-  //   var cardContainer = this.props.cardContainer;
-  //   for (var i = 0; i < cardContainer.length; i++) {
-  //     if (cardContainer[i].id == clipCard.id) {
-  //       console.log("Matching IDs: " + cardContainer[i].id, " ", clipCard.id)
-  //       clipCard.text = cardContainer[i].text;
-  //       clipCard.mediaPath = cardContainer[i].mediaPath;
-  //     }
-  //   }
-  // }
 
   render() {
     return (
@@ -123,26 +89,3 @@ export default class ClipCard extends React.Component {
 }
 // div id = space
 //             onClick = {this.updateText}
-
-
-
-// <div className="clipCard"
-//   id = {this.state.id}
-//   onClick={this.placeText}
-//   >
-//   <textarea
-//     className="clipText"
-//     name = "clipText"
-//     defaultValue = {this.props.text}
-//     onChange={this.setText}
-//     id = {this.state.id}
-//     >
-//   </textarea>
-//   <div id="space"></div>
-//   <video
-//     id={this.state.id + "-vid"}
-//     src={this.state.clipCard.mediaPath}
-//   >
-//   </video>
-// </div>
-//

--- a/src/ClipCard/ClipCard.jsx
+++ b/src/ClipCard/ClipCard.jsx
@@ -52,25 +52,35 @@ export default class ClipCard extends React.Component {
   // DOESN'T use state, but this function needs to use clipContainer state
   placeText(event) {
     var editorText = document.getElementById("editorText");
-    var clipCard = this.state.clipCard;
-    editorText.value = clipCard.text;
-    editorText.cardkey = this.state.id;
-    editorText.cardindex = this.props.index;
+    // editorText.cardindex = this.props.index;
+    // editorText.cardkey = this.state.id;
+    // var editorTextIndex = editorText.cardindex
+    // var cardContainer = this.props.cardContainer;
+    console.log(event.target.children[1].value)
+    editorText.value = event.target.children[1].value;
+    // var currCardInfo = cardContainer[editorTextIndex]
+    // var currCardText = document.getElementById(currCardInfo['id']).children[0].children[1]
+    // console.log("desired text: ", currCardText.value)
+    // editorText.value = currCardText.value;
+
+    // var clipCard = this.state.clipCard;
+    // console.log(clipCard)
+    // editorText.cardindex = this.props.index;
   }
 
-  updateText(event) {
-    var cardContainer = this.props.cardContainer;
-    // console.log("omg")
-
-    for (var i = 0; i < cardContainer.length; i++) {
-      if (cardContainer[i].id = event.target.id) {
-        console.log("event id: " + event.target.id)
-        console.log("text of cc: " + cardContainer[i].text)
-        event.target.value = cardContainer[i].text;
-      }
-      else { i++ }
-    }
-  }
+  // updateText(event) {
+  //   var cardContainer = this.props.cardContainer;
+  //   // console.log("omg")
+  //
+  //   for (var i = 0; i < cardContainer.length; i++) {
+  //     if (cardContainer[i].id = event.target.id) {
+  //       console.log("event id: " + event.target.id)
+  //       console.log("text of cc: " + cardContainer[i].text)
+  //       event.target.value = cardContainer[i].text;
+  //     }
+  //     else { i++ }
+  //   }
+  // }
 
   // TRIES (fails) to set its text to editor window's text
   // setText(event) {
@@ -98,11 +108,10 @@ export default class ClipCard extends React.Component {
             name = "clipText"
             defaultValue = {this.props.text}
             id = {this.state.id}
-            onClick = {this.updateText}
             >
           </textarea>
         </div>
-        <div id="space"></div>
+        <div id="spce"></div>
         <video
           id={this.state.id + "-vid"}
           src={this.state.clipCard.mediaPath}
@@ -112,6 +121,10 @@ export default class ClipCard extends React.Component {
     )
   }
 }
+// div id = space
+//             onClick = {this.updateText}
+
+
 
 // <div className="clipCard"
 //   id = {this.state.id}

--- a/src/ClipCard/ClipCard.jsx
+++ b/src/ClipCard/ClipCard.jsx
@@ -1,17 +1,9 @@
-// Add packages
+// Import modules
 import React from 'react';
-import './ClipCard.css';
-const osHomedir = require('os-homedir');
-var fs = require("fs");
 var rand = require("random-key");
 
-// Set up FFmpeg
-var fluent_ffmpeg = require('fluent-ffmpeg');
-var mergedVideo = fluent_ffmpeg();
-
-//Import componenets
-import Dropzone from 'react-dropzone';
-
+// Import styles
+import './ClipCard.css';
 
 export default class ClipCard extends React.Component {
   constructor(props) {
@@ -24,8 +16,9 @@ export default class ClipCard extends React.Component {
         },
         id: '',
   		}
-    this.setText = this.setText.bind(this);
+    // this.setText = this.setText.bind(this);
     this.placeText = this.placeText.bind(this);
+    this.updateText = this.updateText.bind(this);
     // this.setMediaPath = this.setMediaPath.bind(this);
     // this.passUp = this.passUp.bind(this);
     this.updateEditor = this.updateEditor.bind(this);
@@ -33,38 +26,30 @@ export default class ClipCard extends React.Component {
 	}
 
   componentDidMount() {
-      // creates a unique ID string for each clip card
+      // creates a unique ID string for each clip card, updates ID state
       var id = rand.generate();
-      this.setState({
-        'id': id,
-      });
-
-      // adds the id to the clip card object
       var clipCard = this.state.clipCard;
       clipCard.id = id;
+
       this.setState({
+        'id': id,
         'clipCard': clipCard,
       });
 
       // adds clip card to app.js card container array
       var cardContainer = this.props.cardContainer;
-      for (var i = 0; i < cardContainer.length; i++) {
-        if (cardContainer[i].id == clipCard.id) {
-          break;
-        }
-      }
       cardContainer.push(clipCard);
       this.props.updateCardContainer(cardContainer);
+      console.log("cardContainer: " + cardContainer)
     }
 
+  // // // // WHAT DOES THIS DO & WHERE IS INDEX FROM // // // //
   updateEditor() {
     this.props.updateEditor(this.props.index);
 	}
 
-  // updateCardContainer() {
-  //   this.props.updateCardContainer(this.state.clipCard)
-  // }
-
+  // MANUALLY puts text/id of individ clipCard into editor window.
+  // DOESN'T use state, but this function needs to use clipContainer state
   placeText(event) {
     var editorText = document.getElementById("editorText");
     var clipCard = this.state.clipCard;
@@ -72,16 +57,32 @@ export default class ClipCard extends React.Component {
     editorText.cardkey = this.state.id;
   }
 
-  setText(event) {
-    var clipCard = this.state.clipCard;
+  updateText(event) {
     var cardContainer = this.props.cardContainer;
+    // console.log("omg")
+
     for (var i = 0; i < cardContainer.length; i++) {
-      if (cardContainer[i].id == clipCard.id) {
-        clipCard.text = cardContainer[i].text;
-        clipCard.mediaPath = cardContainer[i].mediaPath;
+      if (cardContainer[i].id = event.target.id) {
+        console.log("event id: " + event.target.id)
+        console.log("text of cc: " + cardContainer[i].text)
+        event.target.value = cardContainer[i].text;
       }
+      else { i++ }
     }
   }
+
+  // TRIES (fails) to set its text to editor window's text
+  // setText(event) {
+  //   var clipCard = this.state.clipCard;
+  //   var cardContainer = this.props.cardContainer;
+  //   for (var i = 0; i < cardContainer.length; i++) {
+  //     if (cardContainer[i].id == clipCard.id) {
+  //       console.log("Matching IDs: " + cardContainer[i].id, " ", clipCard.id)
+  //       clipCard.text = cardContainer[i].text;
+  //       clipCard.mediaPath = cardContainer[i].mediaPath;
+  //     }
+  //   }
+  // }
 
   render() {
     return (
@@ -93,18 +94,38 @@ export default class ClipCard extends React.Component {
           className="clipText"
           name = "clipText"
           defaultValue = {this.props.text}
-          onChange={this.setText}
           id = {this.state.id}
+          onClick = {this.updateText}
           >
         </textarea>
         <div id="space"></div>
         <video
           id={this.state.id + "-vid"}
-          src={this.state.mediaPath}
-          controls
+          src={this.state.clipCard.mediaPath}
         >
         </video>
       </div>
     )
   }
 }
+
+// <div className="clipCard"
+//   id = {this.state.id}
+//   onClick={this.placeText}
+//   >
+//   <textarea
+//     className="clipText"
+//     name = "clipText"
+//     defaultValue = {this.props.text}
+//     onChange={this.setText}
+//     id = {this.state.id}
+//     >
+//   </textarea>
+//   <div id="space"></div>
+//   <video
+//     id={this.state.id + "-vid"}
+//     src={this.state.clipCard.mediaPath}
+//   >
+//   </video>
+// </div>
+//

--- a/src/ClipCard/ClipCard.jsx
+++ b/src/ClipCard/ClipCard.jsx
@@ -55,6 +55,7 @@ export default class ClipCard extends React.Component {
     var clipCard = this.state.clipCard;
     editorText.value = clipCard.text;
     editorText.cardkey = this.state.id;
+    editorText.cardindex = this.props.index;
   }
 
   updateText(event) {
@@ -90,14 +91,17 @@ export default class ClipCard extends React.Component {
         id = {this.state.id}
         onClick={this.placeText}
         >
-        <textarea
-          className="clipText"
-          name = "clipText"
-          defaultValue = {this.props.text}
-          id = {this.state.id}
-          onClick = {this.updateText}
-          >
-        </textarea>
+        <div id="numbercontainer">
+          <p id="cardindex">{this.props.index}</p>
+          <textarea
+            className="clipText"
+            name = "clipText"
+            defaultValue = {this.props.text}
+            id = {this.state.id}
+            onClick = {this.updateText}
+            >
+          </textarea>
+        </div>
         <div id="space"></div>
         <video
           id={this.state.id + "-vid"}

--- a/src/ClipEditor/ClipEditor.css
+++ b/src/ClipEditor/ClipEditor.css
@@ -7,6 +7,10 @@
   margin: 20px 0;
 }
 
+#clip-instruction {
+  margin: 0px 25px;
+}
+
 #clipEdit-container {
   display: flex;
   position: relative;
@@ -16,7 +20,7 @@
   position: relative;
   width: 200px;
   height: 150px;
-  margin: 25px;
+  margin: 0 25 25 25;
 }
 
 .dropzone-styles {
@@ -26,6 +30,17 @@
 .videotextcontainer {
   display: flex;
   justify-content: space-around;
+}
+
+#buttonalign {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+#updatebtn {
+  text-shadow: none;
+  box-shadow: none;
 }
 
 #scrubber-container {

--- a/src/ClipEditor/ClipEditor.jsx
+++ b/src/ClipEditor/ClipEditor.jsx
@@ -20,25 +20,10 @@ export default class ClipEditor extends React.Component {
         },
       }
       this.updateText = this.updateText.bind(this);
+      this.updateMedia = this.updateMedia.bind(this);
       this.onDrop = this.onDrop.bind(this);
       this.updateCard = this.updateCard.bind(this);
   		}
-
-      // componentDidUpdate() {
-      //   if (!isNaN(this.props.editorEndpoints)) {
-      //     var selected = document.getElementsByClassName('clipCard')[this.props.editorEndpoints].children;
-      //     if ((this.state.clipCard.mediaPath != (selected[0].children[0].children[2].files.length > 0 ? selected[0].children[0].children[2].files[0].path : '')) | this.state.clipCard.text != selected[1].value ) {
-      //       console.log(this.state.clipCard.text)
-      //       this.state.clipCard.mediaPath = selected[0].children[0].children[2].files.length > 0 ? selected[0].children[0].children[2].files[0].path : '';
-      //       this.state.clipCard.text = selected[1].value
-      //       this.setState({
-      //         'clipCard': clipCard
-      //       })
-      //       document.getElementById("editorText").value = selected[1].value;
-      //     }
-      //   }
-      //   console.log(this.state.clipCard)
-      // }
 
       updateText(event) {
         var clipCard = this.state.clipCard;
@@ -60,10 +45,30 @@ export default class ClipEditor extends React.Component {
         }
       }
 
+      updateMedia(event) {
+        var clipCard = this.state.clipCard;
+        clipCard.mediaPath = document.getElementById("editorVideo").src;
+        this.setState({
+          'clipCard': clipCard,
+        });
+
+        var cardContainer = this.props.cardContainer;
+        // var editorText = document.getElementById("editorText")
+        for (var i = 0; i < cardContainer.length; i++) {
+          if (cardContainer[i].id == clipCard.id) {
+            cardContainer[i] = clipCard;
+            this.props.updateCardContainer(cardContainer);
+            console.log(cardContainer)
+            console.log(cardContainer[i])
+          }
+        }
+      }
+
       // on editor window button click, updates the selected card's text/media
       updateCard(event) {
         // Grab editor window textarea element
         var editorText = document.getElementById("editorText");
+        var editorVideo = document.getElementById("editorVideo");
         // grab selected card's index
         var editorTextIndex = document.getElementById("editorText").cardindex;
 
@@ -71,23 +76,31 @@ export default class ClipEditor extends React.Component {
         var cardContainer = this.props.cardContainer;
         // get selected clipcard's info
         var currCardInfo = cardContainer[editorTextIndex]
-        console.log("we're here: ", currCardInfo)
+        console.log("current card state: ", currCardInfo)
         // get the current card's text value
         var currCardText = document.getElementById(currCardInfo['id']).children[0].children[1]
         // update the card's text value to be the editor text's value
         currCardText.value = editorText.value
 
-        var currCardMedia = document.getElementById(currCardInfo['id']).children[2]
-        // currCardMedia.src = currCardInfo['mediaPath']
-        currCardMedia.src = this.state.clipCard.mediaPath;
+        // var currCardMedia = document.getElementById(currCardInfo['id']).children[2].src;
+        var currCardMedia = document.getElementById("editorVideo").src;
 
-        console.log(currCardInfo['mediaPath'])
+        var clipCard = this.state.clipCard;
+        clipCard.mediaPath = currCardMedia;
+        this.setState({
+          'clipCard': clipCard,
+        });
+        // currCardMedia.src = currCardInfo['mediaPath']
+        // currCardMedia.src = this.state.clipCard.mediaPath;
+
+        console.log("card container: ", cardContainer)
       }
 
       onDrop(files) {
         // console.log('dropzone ', files[0].path)
         var clipCard = this.state.clipCard;
-        clipCard.mediaPath = files[0].path;
+        // clipCard.mediaPath = files[0].path;
+        clipCard.mediaPath = document.getElementById("editorVideo").src;
         this.setState({
           'clipCard': clipCard,
         });
@@ -106,6 +119,7 @@ export default class ClipEditor extends React.Component {
         var video = document.getElementById("editorVideo");
         video.src = files[0].path;
         document.getElementById("placeholder").style.display="none";
+
       }
 
     render() {
@@ -126,7 +140,7 @@ export default class ClipEditor extends React.Component {
                     height="360"
                     src={this.state.mediaPath}
                     controls
-                    onChange={this.passMedia}
+                    onChange={this.updateMedia}
                     cardkey=''
                     cardindex=''>
                   </video>

--- a/src/ClipEditor/ClipEditor.jsx
+++ b/src/ClipEditor/ClipEditor.jsx
@@ -68,30 +68,30 @@ export default class ClipEditor extends React.Component {
       updateCard(event) {
         // Grab editor window textarea element
         var editorText = document.getElementById("editorText");
+        // Grab editor window video element
         var editorVideo = document.getElementById("editorVideo");
         // grab selected card's index
-        var editorTextIndex = document.getElementById("editorText").cardindex;
+        var currCardIndex = editorText.cardindex;
 
-        // grab array holding each clipcard's info
+        // grab array from app.js which holds each clipcard's info
         var cardContainer = this.props.cardContainer;
         // get selected clipcard's info
-        var currCardInfo = cardContainer[editorTextIndex]
+        var currCardInfo = cardContainer[currCardIndex]
         console.log("current card state: ", currCardInfo)
-        // get the current card's text value
+        // get the current card's text and video values
         var currCardText = document.getElementById(currCardInfo['id']).children[0].children[1]
-        // update the card's text value to be the editor text's value
+        var currCardMedia = document.getElementById(currCardInfo['id']).children[2];
+        // update the card's text value to be the editor window's text's value
         currCardText.value = editorText.value
-
-        // var currCardMedia = document.getElementById(currCardInfo['id']).children[2].src;
-        var currCardMedia = document.getElementById("editorVideo").src;
+        // update the card's video source to be the editor window's video source
+        currCardMedia.src = editorVideo.src
 
         var clipCard = this.state.clipCard;
-        clipCard.mediaPath = currCardMedia;
+        clipCard.mediaPath = currCardMedia.src;
+        clipCard.text = currCardText.value
         this.setState({
           'clipCard': clipCard,
         });
-        // currCardMedia.src = currCardInfo['mediaPath']
-        // currCardMedia.src = this.state.clipCard.mediaPath;
 
         console.log("card container: ", cardContainer)
       }
@@ -99,21 +99,22 @@ export default class ClipEditor extends React.Component {
       onDrop(files) {
         // console.log('dropzone ', files[0].path)
         var clipCard = this.state.clipCard;
-        // clipCard.mediaPath = files[0].path;
-        clipCard.mediaPath = document.getElementById("editorVideo").src;
+        clipCard.mediaPath = files[0].path;
+        // clipCard.id = document.getElementById("editorText").cardkey;
+        // clipCard.text = document.getElementById("editorText").value;
         this.setState({
           'clipCard': clipCard,
         });
 
         var cardContainer = this.props.cardContainer;
         for (var i = 0; i < cardContainer.length; i++) {
-            if (cardContainer[i].id == clipCard.id) {
-              cardContainer[i] = clipCard;
-              this.props.updateCardContainer(cardContainer);
-              console.log(cardContainer)
-              console.log("card i: ", cardContainer[i])
-            }
+          if (cardContainer[i].id == clipCard.id) {
+            cardContainer[i] = clipCard;
+            this.props.updateCardContainer(cardContainer);
+            console.log(cardContainer)
+            console.log("card i: ", cardContainer[i])
           }
+        }
 
         // var video = document.getElementById("video-input" + this.props.index);
         var video = document.getElementById("editorVideo");

--- a/src/ClipEditor/ClipEditor.jsx
+++ b/src/ClipEditor/ClipEditor.jsx
@@ -61,12 +61,19 @@ export default class ClipEditor extends React.Component {
       }
 
       updateCard(event) {
-        console.log("BTN: update card")
         var editorText = document.getElementById("editorText");
         var editorTextIndex = document.getElementById("editorText").cardindex;
-        console.log(editorTextIndex)
         var cardContainer = this.props.cardContainer;
         console.log("we're here: ", cardContainer[editorTextIndex])
+
+        var currCardInfo = cardContainer[editorTextIndex]
+        var currCardText = document.getElementById(currCardInfo['id']).children[0].children[1]
+        currCardText.value = editorText.value
+
+        var currCardMedia = document.getElementById(currCardInfo['id']).children[2]
+        currCardMedia.src = currCardInfo['mediaPath']
+
+        console.log(currCardInfo['mediaPath'])
       }
 
       onDrop(files) {

--- a/src/ClipEditor/ClipEditor.jsx
+++ b/src/ClipEditor/ClipEditor.jsx
@@ -60,18 +60,26 @@ export default class ClipEditor extends React.Component {
         }
       }
 
+      // on editor window button click, updates the selected card's text/media
       updateCard(event) {
+        // Grab editor window textarea element
         var editorText = document.getElementById("editorText");
+        // grab selected card's index
         var editorTextIndex = document.getElementById("editorText").cardindex;
-        var cardContainer = this.props.cardContainer;
-        console.log("we're here: ", cardContainer[editorTextIndex])
 
+        // grab array holding each clipcard's info
+        var cardContainer = this.props.cardContainer;
+        // get selected clipcard's info
         var currCardInfo = cardContainer[editorTextIndex]
+        console.log("we're here: ", currCardInfo)
+        // get the current card's text value
         var currCardText = document.getElementById(currCardInfo['id']).children[0].children[1]
+        // update the card's text value to be the editor text's value
         currCardText.value = editorText.value
 
         var currCardMedia = document.getElementById(currCardInfo['id']).children[2]
-        currCardMedia.src = currCardInfo['mediaPath']
+        // currCardMedia.src = currCardInfo['mediaPath']
+        currCardMedia.src = this.state.clipCard.mediaPath;
 
         console.log(currCardInfo['mediaPath'])
       }
@@ -94,7 +102,8 @@ export default class ClipEditor extends React.Component {
             }
           }
 
-        var video = document.getElementById("video-input" + this.props.index);
+        // var video = document.getElementById("video-input" + this.props.index);
+        var video = document.getElementById("editorVideo");
         video.src = files[0].path;
         document.getElementById("placeholder").style.display="none";
       }
@@ -113,12 +122,13 @@ export default class ClipEditor extends React.Component {
                   </img>
                   <video
                     id="editorVideo"
-                    id={"video-input" + this.props.index}
                     width="440"
                     height="360"
                     src={this.state.mediaPath}
                     controls
-                    onChange={this.passMedia}>
+                    onChange={this.passMedia}
+                    cardkey=''
+                    cardindex=''>
                   </video>
                 </Dropzone>
             </div>
@@ -145,3 +155,16 @@ export default class ClipEditor extends React.Component {
     )
   }
 }
+
+// id={"video-input" + this.props.index}
+
+
+// <video
+//   id="editorVideo"
+//   id={"video-input" + this.props.index}
+//   width="440"
+//   height="360"
+//   src={this.state.mediaPath}
+//   controls
+//   onChange={this.passMedia}>
+// </video>

--- a/src/ClipEditor/ClipEditor.jsx
+++ b/src/ClipEditor/ClipEditor.jsx
@@ -1,25 +1,21 @@
+// Import modules
 import React from 'react';
-import ReactDOM from 'react-dom';
-import './ClipEditor.css';
-const osHomedir = require('os-homedir');
-var fs = require("fs");
-
-// Set up FFmpeg
-var fluent_ffmpeg = require('fluent-ffmpeg');
-var mergedVideo = fluent_ffmpeg();
-
-// Import componenets
+// import ReactDOM from 'react-dom';
 import Dropzone from 'react-dropzone';
+
+// Import styles
+import './ClipEditor.css';
 
 
 export default class ClipEditor extends React.Component {
   constructor(props) {
 		super(props);
   		this.state = {
-        text: 'Choose a clipcard',
+        text: 'Choose a clipcard from below',
         clipCard: {
           mediaPath: '',
-          text: props.text,
+          // text: props.text,
+          text: '',
           id: ''
         },
       }

--- a/src/ClipEditor/ClipEditor.jsx
+++ b/src/ClipEditor/ClipEditor.jsx
@@ -21,6 +21,7 @@ export default class ClipEditor extends React.Component {
       }
       this.updateText = this.updateText.bind(this);
       this.onDrop = this.onDrop.bind(this);
+      this.updateCard = this.updateCard.bind(this);
   		}
 
       // componentDidUpdate() {
@@ -59,6 +60,15 @@ export default class ClipEditor extends React.Component {
         }
       }
 
+      updateCard(event) {
+        console.log("BTN: update card")
+        var editorText = document.getElementById("editorText");
+        var editorTextIndex = document.getElementById("editorText").cardindex;
+        console.log(editorTextIndex)
+        var cardContainer = this.props.cardContainer;
+        console.log("we're here: ", cardContainer[editorTextIndex])
+      }
+
       onDrop(files) {
         // console.log('dropzone ', files[0].path)
         var clipCard = this.state.clipCard;
@@ -86,10 +96,10 @@ export default class ClipEditor extends React.Component {
       return (
       <div>
         <div ref={"clipEditor"} className="clipEditor">
+          <p className="clip-instruction">Add/edit text and video for the selected card. Press "Update Card" when you're done!</p>
             <div className="videotextcontainer">
               <div className="dropzone">
                 <Dropzone className="dropzone-styles" onDrop={this.onDrop.bind(this)}>
-                  <p className="clip-instruction">Drop or click to add a video.</p>
                   <img
                     id="placeholder"
                     src="./placehold.png">
@@ -105,13 +115,23 @@ export default class ClipEditor extends React.Component {
                   </video>
                 </Dropzone>
             </div>
-            <textarea
-              id="editorText"
-              defaultValue={this.state.text}
-              onChange={this.updateText}
-              cardkey=''
-            >
-            </textarea>
+            <div id="buttonalign">
+              <textarea
+                id="editorText"
+                defaultValue={this.state.text}
+                onChange={this.updateText}
+                cardkey=''
+                cardindex=''
+              >
+              </textarea>
+              <button
+                id="updatebtn"
+                className="button-dark"
+                onClick={this.updateCard}
+              >
+                Update card!
+              </button>
+          </div>
           </div>
         </div>
       </div>

--- a/src/app.js
+++ b/src/app.js
@@ -58,6 +58,7 @@ export default class App extends React.Component {
     this.trackTime = this.trackTime.bind(this);
     this.closeModal = this.closeModal.bind(this);
     this.updateEditor = this.updateEditor.bind(this);
+    this.playPreview = this.playPreview.bind(this);
   }
 
   // State manager for global presets
@@ -149,15 +150,17 @@ export default class App extends React.Component {
 
   // Grabs each media path and plays them in sequence onClick (soon will change)
   playPreview(event) {
-    var videoObjects = document.getElementsByClassName('clipCard');
+    // var videoObjects = document.getElementsByClassName('clipCard');
+    var videoObjects = this.state.cardContainer;
     var previewScreen = document.getElementById("previewscreen");
-    var nextBtn = document.getElementById("nextbtn");
     //grabs data index set on preview screen element
     var currIndex = parseInt(previewScreen.dataset["index"]);
     // grabs path of video
-    var video = videoObjects[currIndex].children[0].children[0].children[2].files[0].path
+    // var video = videoObjects[currIndex].children[2].src
+    var video = videoObjects[currIndex].mediaPath;
     // grabs HTML video element to get video timing
-    var videocontainer = videoObjects[currIndex].children[0].children[0].children[1];
+    // var videocontainer = videoObjects[currIndex].children[2]
+    var videocontainer = document.getElementById("editorVideo")
 
     previewScreen.src = video;
     console.log("video length: " + videocontainer.duration);
@@ -175,11 +178,12 @@ export default class App extends React.Component {
 
   //play video clips in sequence for previewing. Pause after final video.
   trackTime(event) {
-    var videoObjects = document.getElementsByClassName('clipCard');
+    // var videoObjects = document.getElementsByClassName('clipCard');
+    var videoObjects = this.state.cardContainer;
     var previewscreen = document.getElementById("previewscreen");
     var currIndex = parseInt(previewscreen.dataset["index"])
     // grabs all text chunks
-    var text = document.getElementsByClassName("clipText");
+    // var text = document.getElementsByClassName("clipText");
     // grabs <p> div stacked over video
     var videotext = document.getElementById("checkthis");
 
@@ -193,10 +197,12 @@ export default class App extends React.Component {
       if (previewscreen.currentTime == previewscreen.duration) {
         console.log("THEY'RE EQUAL");
         previewscreen.dataset["index"] = Number(previewscreen.dataset["index"]) + 1;
-        previewscreen.src = videoObjects[currIndex].children[0].children[0].children[1].src;
+        // previewscreen.src = videoObjects[currIndex].children[2].src;
+        previewscreen.src = videoObjects[currIndex].mediaPath;
 
-        console.log("text: ", text[currIndex].innerHTML/*,", global preset color: ", this.state.globalPresets*/);
-        videotext.innerHTML = text[currIndex].innerHTML;
+        // console.log("text: ", text[currIndex].innerHTML/*,", global preset color: ", this.state.globalPresets*/);
+        // videotext.innerHTML = text[currIndex].innerHTML;
+        videotext.innerHTML = videoObjects[currIndex].text;
       }
       Number(previewscreen.dataset["index"]) + 1
     }
@@ -262,23 +268,19 @@ export default class App extends React.Component {
   concatClips(event) {
     var processMessages = document.getElementById("process-info");
     processMessages.innerHTML += "Getting started! Give us a few. "
-    //  document.getElementsByClassName('clipCard')[0].children[0].files[0].path
-    var videoObjects = document.getElementsByClassName('clipCard');
+    var videoObjects = this.state.cardContainer;
     var check = 0;
     var globalPresets = this.state.globalPresets;
     var app = this;
 
-    //This is to grab the media path: videoObjects[i].children[0].files[0].path
-    //This is to grab the text segment: videoObjects[i].children[1].value
     for (var i = 0; i < videoObjects.length; i++) {
       var outStream = fs.createWriteStream(i + '.mov');
-      // var outStream = fs.createWriteStream(tmpobj.name +'/' + i + '.mov');
-      fluent_ffmpeg(videoObjects[i].children[0].children[0].children[2].files[0].path)
+      fluent_ffmpeg(videoObjects[i].mediaPath)
         .videoFilters({
           filter: 'drawtext',
           options: {
             fontfile: this.state.globalPresets.font,
-            text: videoObjects[i].children[1].value,
+            text: videoObjects[i].text,
             fontsize: 50,
             fontcolor: this.state.globalPresets.color,
             shadowcolor: 'black',

--- a/src/app.js
+++ b/src/app.js
@@ -72,7 +72,7 @@ export default class App extends React.Component {
   updateIds(updatedIds) {
     this.setState({ ids: updatedIds });
   }
-  
+
   componentDidMount() {
     console.log("cardContainer: ", this.state.cardContainer)
   }


### PR DESCRIPTION
Added a button to manage UI rendering issues in editor window and clip cards. Updated video-making function to reflect these changes.

Working on a persistent state issue where either:
* ClipContainer state auto-updates each card to be equal to the last item’s state if
```
clipCard.id = document.getElementById("editorText").cardkey;  
clipCard.text = document.getElementById("editorText").value;
``` 
is in the code. OR...
* ClipContainer doesn’t update media path unless the text changes